### PR TITLE
Expandable rows

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -60,7 +60,7 @@
              :css-dirs ["resources/public/css"] ;; watch and update CSS
 
              ;; Start an nREPL server into the running figwheel process
-             ;; :nrepl-port 7888
+             :nrepl-port 7888
 
              ;; Server Ring Handler (optional)
              ;; if you want to embed a ring handler into the figwheel http-kit

--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -1,2 +1,4 @@
-/* some style */
+.number-button-indicator:hover {
+  border: 1px solid gray;
+}
 

--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -1,3 +1,4 @@
 .number-button-indicator-hoverable:hover {
+  border: 1px solid gray;
 }
 

--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -1,4 +1,3 @@
-.number-button-indicator:hover {
-  border: 1px solid gray;
+.number-button-indicator-hoverable:hover {
 }
 

--- a/src/cljs_datagrid/demo.cljs
+++ b/src/cljs_datagrid/demo.cljs
@@ -7,8 +7,7 @@
 (defn init-db []
   (let [weight        (/ 1 3)
         common-config {:visible      true
-                       :width-weight weight
-                       :extra-fields [:person/telephone]}
+                       :width-weight weight}
         people        [{:person/first-name "Sonny"
                         :person/last-name  "Su"
                         :person/email      "sonny.su@foobar.com"
@@ -24,7 +23,6 @@
         app-state     (reagent/atom {:window-dimension {:width  (. js/window -innerWidth)
                                                         :height (. js/window -innerHeight)}
                                      :left-corner-block (fn [grid-state style] ;; This fn should be able to merge provided
-
                                                                                ;; styles with it's top-level node, so we
                                                                                ;; are able to set it's width for example.
                                                           [:div {:style (merge {:display :table-cell
@@ -41,8 +39,10 @@
                                                          (println "deleting" rows))
                                      :columns-config   [[:person/first-name (merge common-config {:unique           true
                                                                                                   :render-header-fn (constantly "First Name")})]
-                                                        [:person/last-name (merge common-config {:render-header-fn (constantly "Last Name")})]
-                                                        [:person/email (merge common-config {:render-header-fn (constantly "Email")})]]})]
+                                                        [:person/last-name  (merge common-config {:render-header-fn (constantly "Last Name")})]
+                                                        [:person/email      (merge common-config {:render-header-fn (constantly "Email")})]
+                                                        [:person/telephone  (merge common-config {:extra? true
+                                                                                                  :render-header-fn (constantly "Telephone")})]]})]
     app-state))
 
 (defonce grid-state (init-db))

--- a/src/cljs_datagrid/demo.cljs
+++ b/src/cljs_datagrid/demo.cljs
@@ -19,12 +19,18 @@
                         :person/email "jane.doe@foobar.com"}]
         app-state     (reagent/atom {:window-dimension {:width  (. js/window -innerWidth)
                                                         :height (. js/window -innerHeight)}
-                                     :left-corner-block (fn [grid-state]
-                                                          [:div {:class    "mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab mdl-button--colored"}
-                                                           [:i {:class "material-icons"
-                                                                :on-click #(let [id (:id @grid-state)
-                                                                                 div-rows (js/document.getElementById (str "grid-" id "rows"))]
-                                                                             (swap! grid-state update-in [:rows] conj {}))} "add"]])
+                                     :left-corner-block (fn [grid-state style] ;; This fn should be able to merge provided
+                                                                               ;; styles with it's top-level node, so we
+                                                                               ;; are able to set it's width for example.
+                                                          [:div {:style (merge {:display :table-cell
+                                                                                :vertical-align :middle
+                                                                                :text-align :center}
+                                                                               style)}
+                                                           [:div {:class "mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab mdl-button--colored"}
+                                                            [:i {:class "material-icons"
+                                                                 :on-click #(let [id (:id @grid-state)
+                                                                                  div-rows (js/document.getElementById (str "grid-" id "rows"))]
+                                                                              (swap! grid-state update-in [:rows] conj {}))} "add"]]])
                                      :rows             people
                                      :on-delete-rows   (fn [rows]
                                                          (println "deleting" rows))

--- a/src/cljs_datagrid/demo.cljs
+++ b/src/cljs_datagrid/demo.cljs
@@ -15,11 +15,11 @@
                        {:person/first-name "John"
                         :person/last-name  "Smith"
                         :person/email      "john.smith@foobar.com"
-                        :person/telephone  "123"}
+                        :person/telephone  "1234"}
                        {:person/first-name "Jane"
                         :person/last-name  "Doe"
                         :person/email      "jane.doe@foobar.com"
-                        :person/telephone  "123"}]
+                        :person/telephone  "12345"}]
         app-state     (reagent/atom {:window-dimension {:width  (. js/window -innerWidth)
                                                         :height (. js/window -innerHeight)}
                                      :left-corner-block (fn [grid-state style] ;; This fn should be able to merge provided

--- a/src/cljs_datagrid/demo.cljs
+++ b/src/cljs_datagrid/demo.cljs
@@ -6,7 +6,7 @@
 
 (defn init-db []
   (let [weight        (/ 1 3)
-        common-config {:visible      true
+        common-config {:visible?      true
                        :width-weight weight}
         people        [{:person/first-name "Sonny"
                         :person/last-name  "Su"

--- a/src/cljs_datagrid/demo.cljs
+++ b/src/cljs_datagrid/demo.cljs
@@ -7,19 +7,24 @@
 (defn init-db []
   (let [weight        (/ 1 3)
         common-config {:visible      true
-                       :width-weight weight}
+                       :width-weight weight
+                       :extra-fields [:person/telephone]}
         people        [{:person/first-name "Sonny"
                         :person/last-name  "Su"
-                        :person/email      "sonny.su@foobar.com"}
+                        :person/email      "sonny.su@foobar.com"
+                        :person/telephone  "123"}
                        {:person/first-name "John"
                         :person/last-name  "Smith"
-                        :person/email      "john.smith@foobar.com"}
+                        :person/email      "john.smith@foobar.com"
+                        :person/telephone  "123"}
                        {:person/first-name "Jane"
                         :person/last-name "Doe"
-                        :person/email "jane.doe@foobar.com"}]
+                        :person/email "jane.doe@foobar.com"
+                        :person/telephone "123"}]
         app-state     (reagent/atom {:window-dimension {:width  (. js/window -innerWidth)
                                                         :height (. js/window -innerHeight)}
                                      :left-corner-block (fn [grid-state style] ;; This fn should be able to merge provided
+
                                                                                ;; styles with it's top-level node, so we
                                                                                ;; are able to set it's width for example.
                                                           [:div {:style (merge {:display :table-cell

--- a/src/cljs_datagrid/demo.cljs
+++ b/src/cljs_datagrid/demo.cljs
@@ -11,15 +11,23 @@
         people        [{:person/first-name "Sonny"
                         :person/last-name  "Su"
                         :person/email      "sonny.su@foobar.com"
-                        :person/telephone  "123"}
+                        :person/telephone  "123"
+                        :person/gender     "M"}
                        {:person/first-name "John"
                         :person/last-name  "Smith"
                         :person/email      "john.smith@foobar.com"
-                        :person/telephone  "1234"}
+                        :person/telephone  "1234"
+                        :person/gender     "M"}
                        {:person/first-name "Jane"
                         :person/last-name  "Doe"
                         :person/email      "jane.doe@foobar.com"
-                        :person/telephone  "12345"}]
+                        :person/telephone  "12345"
+                        :person/gender     "F"}
+                       {:person/first-name "Jane"
+                        :person/last-name  "Austen"
+                        :person/email      "jane.austen@foobar.com"
+                        :person/telephone  "123456"
+                        :person/gender     "F"}]
         app-state     (reagent/atom {:window-dimension {:width  (. js/window -innerWidth)
                                                         :height (. js/window -innerHeight)}
                                      :left-corner-block (fn [grid-state style] ;; This fn should be able to merge provided
@@ -42,7 +50,9 @@
                                                         [:person/last-name  (merge common-config {:render-header-fn (constantly "Last Name")})]
                                                         [:person/email      (merge common-config {:render-header-fn (constantly "Email")})]
                                                         [:person/telephone  (merge common-config {:extra? true
-                                                                                                  :render-header-fn (constantly "Telephone")})]]})]
+                                                                                                  :render-header-fn (constantly "Telephone")})]
+                                                        [:person/gender     (merge common-config {:extra? true
+                                                                                                  :render-header-fn (constantly "Gender")})]]})]
     app-state))
 
 (defonce grid-state (init-db))

--- a/src/cljs_datagrid/demo.cljs
+++ b/src/cljs_datagrid/demo.cljs
@@ -17,9 +17,9 @@
                         :person/email      "john.smith@foobar.com"
                         :person/telephone  "123"}
                        {:person/first-name "Jane"
-                        :person/last-name "Doe"
-                        :person/email "jane.doe@foobar.com"
-                        :person/telephone "123"}]
+                        :person/last-name  "Doe"
+                        :person/email      "jane.doe@foobar.com"
+                        :person/telephone  "123"}]
         app-state     (reagent/atom {:window-dimension {:width  (. js/window -innerWidth)
                                                         :height (. js/window -innerHeight)}
                                      :left-corner-block (fn [grid-state style] ;; This fn should be able to merge provided

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -4,7 +4,7 @@
             [reagent.core :as r]
             [cljsjs.hammer]))
 
-(defonce left-corner-block-width 40)
+(defonce left-corner-block-width 60)
 (defonce common-column-style {:display :table-cell
                               :padding 0
                               :border  "1px solid #d9d9d9"})
@@ -172,15 +172,16 @@
         hover-style     (fn [] (when (= i @hovered-nb-row)
                                  {:background-color "#d9d9d9"}))
         hover-indicator (fn [] (when (= i @hovered-nb-row)
-                                 [:i.number-button-indicator.material-icons {:style {:margin-left 5
-                                                                                     :margin-right -10}
-                                                                             :on-click (fn [evt]
-                                                                                         (if (tily/is-contained? i :in @expanded-rows)
-                                                                                           (collapse-row)
-                                                                                           (expand-row))
-                                                                                         (.. evt stopPropagation)
-                                                                                         (.. evt -nativeEvent stopImmediatePropagation))}
-                                  "arrow_drop_down"]))]
+                                 [:i {:class "number-button-indicator material-icons"
+                                      :style {:margin-left    5
+                                              :margin-right -10}
+                                      :on-click (fn [evt]
+                                                  (if (tily/is-contained? i :in @expanded-rows)
+                                                    (collapse-row)
+                                                    (expand-row))
+                                                  (.. evt stopPropagation)
+                                                  (.. evt -nativeEvent stopImmediatePropagation))}
+              "arrow_drop_down"]))]
     (r/create-class {:component-did-mount (fn [this-component]
                                             (let [this-element (r/dom-node this-component)
                                                   mc (js/Hammer. this-element)]

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -292,7 +292,7 @@
                             [:div {:style style}
                              [number-button i grid-state]
                              (row-data row)]
-                            [extra-row-div]]))]
+                            [extra-row-div i]]))]
     [:div {:id    (tily/format "grid-%s-rows" id)
            :class "grid-rows"
            :style {:display    :block

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -158,11 +158,17 @@
     [:div property
      value]))
 
+
+;; temporary atom, just to check
+(def number-button-hover? (r/atom false))
+
 (defn- number-button [i grid-state]
   (let [selected-rows (r/cursor grid-state [:selected-rows])
         select-row    #(swap! selected-rows conj i)
         unselect-row  (fn [] (swap! selected-rows (fn [selected-rows]
-                                                    (set (filter #(not= i %) selected-rows)))))]
+                                                    (set (filter #(not= i %) selected-rows)))))
+        build-style   (fn [] (if @number-button-hover?
+                               {:background-color "red"}))]
     (r/create-class {:component-did-mount (fn [this-component]
                                             (let [this-element (r/dom-node this-component)
                                                   mc (js/Hammer. this-element)]
@@ -201,14 +207,18 @@
                                        [:div {:id i
                                               :draggable       true
                                               :class           "mdl-button mdl-js-button mdl-js-button mdl-button--raised"
-                                              :style           {:display   :table-cell
-                                                                :width     left-corner-block-width
-                                                                :min-width left-corner-block-width
-                                                                :max-width left-corner-block-width
-                                                                :padding   0}
+                                              :style           (merge
+                                                                 {:display   :table-cell
+                                                                  :width     left-corner-block-width
+                                                                  :min-width left-corner-block-width
+                                                                  :max-width left-corner-block-width
+                                                                  :padding   0}
+                                                                 (build-style))
                                               :on-click        #(if (tily/is-contained? i :in @selected-rows)
                                                                   (unselect-row)
                                                                   (select-row))
+                                              :on-mouse-enter  (fn [_] (reset! number-button-hover? true))
+                                              :on-mouse-leave  (fn [_] (reset! number-button-hover? false))
                                               :on-drag-start   (fn [evt]
                                                                  (let [selected-row-indexes  (-> @grid-state (get-in [:selected-rows]))
                                                                        selected-entities     (-> @grid-state :rows

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -112,7 +112,7 @@
 (defn- column-headers [grid-state]
   (let [left-corner-block (or (:left-corner-block @grid-state)
                               (fn [grid-state]
-                                [:div {:class "mdl-button mdl-js-button mdl-js-button mdl-button--raised"
+                                [:div {:class "mdl-button mdl-js-button mdl-button--raised"
                                        :style {:display   :table-cell
                                                :width     left-corner-block-width
                                                :min-width left-corner-block-width

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -264,6 +264,10 @@
                                         (inc i)
                                         [hover-indicator i]])})))
 
+(defn- div* []
+  [:div {:style {:display :none}}
+   "a hidden div"])
+
 (defn- rows [grid-state]
   (let [id             (-> @grid-state :id)
         total-width    (get-content-width grid-state)
@@ -283,10 +287,11 @@
                                style (if (tily/is-contained? i :in @selected-rows)
                                        (assoc style :background-color "#e6faff")
                                        style)]
-                           [:div {:key   (tily/format "grid-%s-%s" id i)
-                                  :style style}
-                            [number-button i grid-state]
-                            (row-data row)]))]
+                           [:div {:key   (tily/format "grid-%s-%s" id i)}
+                            [:div {:style style}
+                             [number-button i grid-state]
+                             (row-data row)]
+                            [div*]]))]
     [:div {:id    (tily/format "grid-%s-rows" id)
            :class "grid-rows"
            :style {:display    :block

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -171,14 +171,14 @@
         hover-style     (fn [] (when (= i @hovered-nb-row)
                                  {:background-color "#d9d9d9"}))
         hover-indicator (fn [] (when (= i @hovered-nb-row)
-                                 [:i.material-icons {:style {:margin       -5
-                                                             :margin-right -8}
-                                                      :on-click (fn [evt]
-                                                                  (if (tily/is-contained? i :in @expanded-rows)
-                                                                    (collapse-row)
-                                                                    (expand-row))
-                                                                  (.. evt stopPropagation)
-                                                                  (.. evt -nativeEvent stopImmediatePropagation))}
+                                 [:i.number-button-indicator.material-icons {:style {:margin       -5
+                                                                                     :margin-right -8}
+                                                                             :on-click (fn [evt]
+                                                                                         (if (tily/is-contained? i :in @expanded-rows)
+                                                                                           (collapse-row)
+                                                                                           (expand-row))
+                                                                                         (.. evt stopPropagation)
+                                                                                         (.. evt -nativeEvent stopImmediatePropagation))}
                                   "arrow_drop_down"]))]
     (r/create-class {:component-did-mount (fn [this-component]
                                             (let [this-element (r/dom-node this-component)

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -64,17 +64,11 @@
                      common-column-style)]
     style))
 
-;; rename this fn
-(defn filter-normal-columns [column-config]
-  (let [[column-kw config] column-config]
-    (js/console.log (pr-str column-kw))
-    column-config))
-
-
 (defn- data-column-headers [grid-state]
   (doall (for [column-config (-> @grid-state :columns-config)
-               :let [[column-kw config] (filter-normal-columns column-config)
-                     column-width   (get-column-width column-kw grid-state)
+               :let [[column-kw config] column-config]
+               :when (not (:extra? config))
+               :let [column-width   (get-column-width column-kw grid-state)
                      header-txt     (-> config :render-header-fn (apply nil))
                      sort-indicator (let [sort-column (-> @grid-state :sort-column)
                                           column      (-> sort-column keys first)

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -293,10 +293,10 @@
         expanded-rows   (r/cursor grid-state [:expanded-rows])
         row-data        (fn [row]
                           (doall (for [[column-kw config] columns-config
-                                       :let [render-column-fn (:render-column-fn config)
-                                             k                (tily/format "grid-%s-%s-%s" id (:system/id @row) column-kw)]
                                        :when (:visible config)
-                                       :when (not (:extra? config))]
+                                       :when (not (:extra? config))
+                                       :let [render-column-fn (:render-column-fn config)
+                                             k                (tily/format "grid-%s-%s-%s" id (:system/id @row) column-kw)]]
                                    (if render-column-fn
                                      ^{:key k} [render-column-fn column-kw row grid-state]
                                      ^{:key k} [default-column-render column-kw row grid-state]))))
@@ -310,9 +310,9 @@
                              (row-data row)]))
         extra-row-data  (fn [row]
                           (doall (for [[column-kw config] columns-config
+                                       :when (:extra? config)
                                        :let [render-column-fn (:render-column-fn config)
-                                             k                (tily/format "grid-%s-%s-%s-extra" id (:system/id @row) column-kw)]
-                                       :when (:extra? config)]
+                                             k                (tily/format "grid-%s-%s-%s-extra" id (:system/id @row) column-kw)]]
                                   (if render-column-fn
                                      ^{:key k} [render-column-fn column-kw row grid-state]
                                      ^{:key k} [default-column-render column-kw row grid-state]))))

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -24,11 +24,11 @@
 
 (defn get-invisible-columns [grid-state]
   (->> @grid-state :columns-config
-       (filter #(false? (-> % second :visible)))))
+       (filter #(false? (-> % second :visible?)))))
 
 (defn get-visible-columns [grid-state]
   (->> @grid-state :columns-config
-       (filter #(true? (-> % second :visible)))))
+       (filter #(true? (-> % second :visible?)))))
 
 (defn get-content-width [grid-state]
   (-> grid-state get-window-dimension :width))
@@ -159,7 +159,6 @@
                        (assoc property :on-input remote-save))]
     [:div property
      value]))
-
 
 (defn- number-button [i grid-state]
   (let [selected-rows   (r/cursor grid-state [:selected-rows])
@@ -293,7 +292,7 @@
         expanded-rows   (r/cursor grid-state [:expanded-rows])
         row-data        (fn [row]
                           (doall (for [[column-kw config] columns-config
-                                       :when (:visible config)
+                                       :when (:visible? config)
                                        :when (not (:extra? config))
                                        :let [render-column-fn (:render-column-fn config)
                                              k                (tily/format "grid-%s-%s-%s" id (:system/id @row) column-kw)]]
@@ -310,7 +309,7 @@
                              (row-data row)]))
         extra-row-data  (fn [row]
                           (doall (for [[column-kw config] columns-config
-                                       :when (:visible config)
+                                       :when (:visible? config)
                                        :when (:extra? config)
                                        :let [render-column-fn (:render-column-fn config)
                                              k                (tily/format "grid-%s-%s-%s-extra" id (:system/id @row) column-kw)]]

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -292,13 +292,15 @@
                                   (if render-column-fn
                                     ^{:key k} [render-column-fn column-kw row grid-state]
                                     ^{:key k} [default-column-render column-kw row grid-state]))))
+        extra-row-data  (fn [i]
+                          [:div {:style (when-not (tily/is-contained? i :in @expanded-rows)
+                                          {:display :none})}
+                           (for [column-config (-> @grid-state :columns-config)
+                                 :let [[column-kw config] column-config]
+                                 :when (:extra? config)]
+                             column-kw)])
         extra-row-div  (fn [i]
-                         [:div {:style (when-not (tily/is-contained? i :in @expanded-rows)
-                                         {:display :none})}
-                          (for [column-config (-> @grid-state :columns-config)
-                                :let [[column-kw config] column-config]
-                                :when (:extra? config)]
-                            column-kw)])
+                         [extra-row-data i])
         row-div        (fn [i row]
                          (let [style {:display :table-row}
                                style (if (tily/is-contained? i :in @selected-rows)

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -98,7 +98,7 @@
                                                                                                  clojure.string/lower-case)
                                                                                             comparator
                                                                                             rows))))))))))]
-               :when (:visible config)]
+               :when (:visible? config)]
            [:div {:key      (tily/format "grid-%s-%s-header" (:id @grid-state) column-kw)
                   :class    "mdl-button mdl-js-button mdl-js-button mdl-button--raised"
                   :style    (merge {:display   :table-cell
@@ -294,7 +294,7 @@
                            (doall (for [[column-kw config] columns-config
                                         ;; use get-visible-columns, write filter-default-columns, etc.
                                         :when (if extra? (= extra? (:extra? config)) true)
-                                        :when (if visible? (= visible? (:visible config)) true)
+                                        :when (if visible? (= visible? (:visible? config)) true)
                                         :let [render-column-fn (:render-column-fn config)
                                               k                (reagent-key-fn (:system/id @row) column-kw)]]
                                     (if render-column-fn
@@ -389,12 +389,12 @@
                           :list-style-type :none}}
              (for [[i [column-kw config]] (tily/with-index columns-config)
                    :let [k (tily/format "spreadsheet-%s-cog-%s" id column-kw)
-                         visible? (:visible config)
+                         visible? (:visible? config)
                          ch (-> config :render-header-fn (apply nil))]]
                [:li {:key k}
                 [:label {:class "mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect" :for k}
                  [:input {:type "checkbox" :id k :class "mdl-checkbox__input" :defaultChecked visible?
-                          :on-change #(swap! grid-state update-in [:columns-config i 1 :visible] not)}]
+                          :on-change #(swap! grid-state update-in [:columns-config i 1 :visible?] not)}]
                  [:span {:class "mdl-checkbox__label"} ch]]])]])]))))
 
 (defn render [grid-state]

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -110,16 +110,17 @@
             sort-indicator])))
 
 (defn- column-headers [grid-state]
-  (let [left-corner-block (or (:left-corner-block @grid-state)
-                              (fn [grid-state]
-                                [:div {:class "mdl-button mdl-js-button mdl-button--raised"
-                                       :style {:display   :table-cell
-                                               :width     left-corner-block-width
-                                               :min-width left-corner-block-width
-                                               :max-width left-corner-block-width
-                                               :padding   0}}]))]
+  (let [left-corner-block-style {:display   :table-cell
+                                 :width     left-corner-block-width
+                                 :min-width left-corner-block-width
+                                 :max-width left-corner-block-width
+                                 :padding   0}
+        left-corner-block       (or (:left-corner-block @grid-state)
+                                    (fn [grid-state style]
+                                      [:div {:class "mdl-button mdl-js-button mdl-button--raised"
+                                             :style style}]))]
     [:div {:style {:display :table-row}}
-     (left-corner-block grid-state)
+     (left-corner-block grid-state left-corner-block-style)
      (data-column-headers grid-state)]))
 
 (defn- default-column-render [column-kw row grid-state]

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -172,8 +172,10 @@
                                  {:background-color "#d9d9d9"}))
         hover-indicator (fn [] (when (= i @hovered-nb-row)
                                  [:i.material-icons {:style {:margin       -5
-                                                              :margin-right -8}
-                                                      :on-click #(js/alert "click")}
+                                                             :margin-right -8}
+                                                      :on-click #(if (tily/is-contained? i :in @expanded-rows)
+                                                                    (collapse-row)
+                                                                    (expand-row))}
                                   "arrow_drop_down"]))]
     (r/create-class {:component-did-mount (fn [this-component]
                                             (let [this-element (r/dom-node this-component)

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -279,8 +279,10 @@
                                   (if render-column-fn
                                     ^{:key k} [render-column-fn column-kw row grid-state]
                                     ^{:key k} [default-column-render column-kw row grid-state]))))
-        extra-row-div  (fn [] [:div {:style {:display :none}}
-                               "a hidden div"])
+        extra-row-div  (fn [i]
+                         [:div {:style (when-not (tily/is-contained? i :in @expanded-rows)
+                                         {:display :none})}
+                          "a hidden div"])
         row-div        (fn [i row]
                          (let [style {:display :table-row}
                                style (if (tily/is-contained? i :in @selected-rows)

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -168,10 +168,10 @@
                                                       (set (filter #(not= i %) selected-rows)))))
         expand-row      (fn [] (swap! expanded-rows conj i))
         collapse-row    (fn [] (swap! expanded-rows disj i))
-        hover-style     (fn [i] (when (= i @hovered-nb-row)
-                                  {:background-color "#d9d9d9"}))
-        hover-indicator (fn [i] (when (= i @hovered-nb-row)
-                                  [:i.material-icons {:style {:margin       -5
+        hover-style     (fn [] (when (= i @hovered-nb-row)
+                                 {:background-color "#d9d9d9"}))
+        hover-indicator (fn [] (when (= i @hovered-nb-row)
+                                 [:i.material-icons {:style {:margin       -5
                                                               :margin-right -8}
                                                       :on-click #(js/alert "click")}
                                   "arrow_drop_down"]))]
@@ -219,7 +219,7 @@
                                                                   :min-width left-corner-block-width
                                                                   :max-width left-corner-block-width
                                                                   :padding   0}
-                                                                 (hover-style i))
+                                                                 (hover-style))
                                               :on-click        #(if (tily/is-contained? i :in @selected-rows)
                                                                   (unselect-row)
                                                                   (select-row))
@@ -265,7 +265,7 @@
 
                                                                    (. evt preventDefault)))}
                                         (inc i)
-                                        [hover-indicator i]])})))
+                                        [hover-indicator]])})))
 
 (defn- rows [grid-state]
   (let [id             (-> @grid-state :id)

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -169,9 +169,10 @@
                                                       (set (filter #(not= i %) selected-rows)))))
         hover-style     (fn [i] (when (= i @number-button-hover-id)
                                   {:background-color "#d9d9d9"}))
-        hover-indicator (fn [] (when (= i @number-button-hover-id)
-                                 [:i.material-icons {:style {:margin -5 :margin-right -8}
-                                                     :on-click #(js/alert "click")}
+        hover-indicator (fn [i] (when (= i @number-button-hover-id)
+                                  [:i.material-icons {:style {:margin       -5
+                                                              :margin-right -8}
+                                                      :on-click #(js/alert "click")}
                                   "arrow_drop_down"]))]
     (r/create-class {:component-did-mount (fn [this-component]
                                             (let [this-element (r/dom-node this-component)
@@ -263,7 +264,7 @@
 
                                                                    (. evt preventDefault)))}
                                         (inc i)
-                                        [hover-indicator]])})))
+                                        [hover-indicator i]])})))
 
 (defn- rows [grid-state]
   (let [id             (-> @grid-state :id)

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -168,7 +168,7 @@
         unselect-row  (fn [] (swap! selected-rows (fn [selected-rows]
                                                     (set (filter #(not= i %) selected-rows)))))
         build-style   (fn [i] (when (= i @number-button-hover-id)
-                                {:background-color "red"}))]
+                                {:background-color "#d9d9d9"}))]
     (r/create-class {:component-did-mount (fn [this-component]
                                             (let [this-element (r/dom-node this-component)
                                                   mc (js/Hammer. this-element)]

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -295,7 +295,10 @@
         extra-row-div  (fn [i]
                          [:div {:style (when-not (tily/is-contained? i :in @expanded-rows)
                                          {:display :none})}
-                          "a hidden div"])
+                          (for [column-config (-> @grid-state :columns-config)
+                                :let [[column-kw config] column-config]
+                                :when (:extra? config)]
+                            column-kw)])
         row-div        (fn [i row]
                          (let [style {:display :table-row}
                                style (if (tily/is-contained? i :in @selected-rows)

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -161,10 +161,13 @@
 
 (defn- number-button [i grid-state]
   (let [selected-rows   (r/cursor grid-state [:selected-rows])
+        expanded-rows  (r/cursor grid-state [:expanded-rows])
         hovered-nb-row  (r/cursor grid-state [:hovered-number-button-row])
         select-row      #(swap! selected-rows conj i)
         unselect-row    (fn [] (swap! selected-rows (fn [selected-rows]
                                                       (set (filter #(not= i %) selected-rows)))))
+        expand-row      (fn [] (swap! expanded-rows conj i))
+        collapse-row    (fn [] (swap! expanded-rows disj i))
         hover-style     (fn [i] (when (= i @hovered-nb-row)
                                   {:background-color "#d9d9d9"}))
         hover-indicator (fn [i] (when (= i @hovered-nb-row)

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -264,10 +264,6 @@
                                         (inc i)
                                         [hover-indicator i]])})))
 
-(defn- extra-row []
-  [:div {:style {:display :none}}
-   "a hidden div"])
-
 (defn- rows [grid-state]
   (let [id             (-> @grid-state :id)
         total-width    (get-content-width grid-state)
@@ -282,6 +278,8 @@
                                   (if render-column-fn
                                     ^{:key k} [render-column-fn column-kw row grid-state]
                                     ^{:key k} [default-column-render column-kw row grid-state]))))
+        extra-row-div  (fn [] [:div {:style {:display :none}}
+                               "a hidden div"])
         row-div        (fn [i row]
                          (let [style {:display :table-row}
                                style (if (tily/is-contained? i :in @selected-rows)
@@ -291,7 +289,7 @@
                             [:div {:style style}
                              [number-button i grid-state]
                              (row-data row)]
-                            [extra-row]]))]
+                            [extra-row-div]]))]
     [:div {:id    (tily/format "grid-%s-rows" id)
            :class "grid-rows"
            :style {:display    :block

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -168,7 +168,9 @@
         unselect-row  (fn [] (swap! selected-rows (fn [selected-rows]
                                                     (set (filter #(not= i %) selected-rows)))))
         build-style   (fn [i] (when (= i @number-button-hover-id)
-                                {:background-color "#d9d9d9"}))]
+                                {:background-color "#d9d9d9"}))
+        hover-arrow   (fn [] (when (= i @number-button-hover-id)
+                               [:i {:class "material-icons"} "arrow_drop_down"]))]
     (r/create-class {:component-did-mount (fn [this-component]
                                             (let [this-element (r/dom-node this-component)
                                                   mc (js/Hammer. this-element)]
@@ -258,7 +260,8 @@
                                                                        (tily/set-atom! grid-state [:context-menu :coordinate] [x y])))
 
                                                                    (. evt preventDefault)))}
-                                        (inc i)])})))
+                                        (inc i)
+                                        [hover-arrow]])})))
 
 (defn- rows [grid-state]
   (let [id             (-> @grid-state :id)

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -170,7 +170,8 @@
         hover-style     (fn [i] (when (= i @number-button-hover-id)
                                   {:background-color "#d9d9d9"}))
         hover-indicator (fn [] (when (= i @number-button-hover-id)
-                                 [:i.material-icons {:style {:margin -5 :margin-right -8}}
+                                 [:i.material-icons {:style {:margin -5 :margin-right -8}
+                                                     :on-click #(js/alert "click")}
                                   "arrow_drop_down"]))]
     (r/create-class {:component-did-mount (fn [this-component]
                                             (let [this-element (r/dom-node this-component)

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -274,8 +274,10 @@
                                                                        (tily/set-atom! grid-state [:context-menu :coordinate] [x y])))
 
                                                                    (. evt preventDefault)))}
-                                        (inc i)
-                                        [hover-indicator]])})))
+                                        (when i
+                                          [:div
+                                           (inc i)
+                                           [hover-indicator]])])})))
 
 (defn- rows [grid-state]
   (let [id              (-> @grid-state :id)
@@ -312,6 +314,7 @@
         extra-row-div   (fn [i row]
                           [:div {:style (when-not (tily/is-contained? i :in @expanded-rows)
                                           {:display :none})}
+                           [number-button nil grid-state]
                            (extra-row-data row)])]
     [:div {:id    (tily/format "grid-%s-rows" id)
            :class "grid-rows"

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -271,7 +271,7 @@
                                                                                                          on-delete-rows (or (:on-delete-rows @grid-state)
                                                                                                                             constantly)]
                                                                                                      (on-delete-rows rows-to-delete)
-
+                                                                                                     (swap! expanded-rows clojure.set/difference @selected-rows)
                                                                                                      (reset! selected-rows #{})
                                                                                                      (tily/set-atom! grid-state [:rows] new-rows)))} "Delete"]]
                                                                        (tily/set-atom! grid-state [:context-menu :content] delete)

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -217,8 +217,8 @@
                                               :on-click        #(if (tily/is-contained? i :in @selected-rows)
                                                                   (unselect-row)
                                                                   (select-row))
-                                              :on-mouse-enter  (fn [_] (reset! number-button-hover-id true))
-                                              :on-mouse-leave  (fn [_] (reset! number-button-hover-id false))
+                                              :on-mouse-enter  (fn [_] (reset! number-button-hover-id i))
+                                              :on-mouse-leave  (fn [_] (reset! number-button-hover-id nil))
                                               :on-drag-start   (fn [evt]
                                                                  (let [selected-row-indexes  (-> @grid-state (get-in [:selected-rows]))
                                                                        selected-entities     (-> @grid-state :rows

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -310,6 +310,7 @@
                              (row-data row)]))
         extra-row-data  (fn [row]
                           (doall (for [[column-kw config] columns-config
+                                       :when (:visible config)
                                        :when (:extra? config)
                                        :let [render-column-fn (:render-column-fn config)
                                              k                (tily/format "grid-%s-%s-%s-extra" id (:system/id @row) column-kw)]]

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -167,8 +167,8 @@
         select-row    #(swap! selected-rows conj i)
         unselect-row  (fn [] (swap! selected-rows (fn [selected-rows]
                                                     (set (filter #(not= i %) selected-rows)))))
-        build-style   (fn [] (if @number-button-hover-id
-                               {:background-color "red"}))]
+        build-style   (fn [i] (when (= i @number-button-hover-id)
+                                {:background-color "red"}))]
     (r/create-class {:component-did-mount (fn [this-component]
                                             (let [this-element (r/dom-node this-component)
                                                   mc (js/Hammer. this-element)]
@@ -213,7 +213,7 @@
                                                                   :min-width left-corner-block-width
                                                                   :max-width left-corner-block-width
                                                                   :padding   0}
-                                                                 (build-style))
+                                                                 (build-style i))
                                               :on-click        #(if (tily/is-contained? i :in @selected-rows)
                                                                   (unselect-row)
                                                                   (select-row))

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -284,7 +284,6 @@
                                            [hover-indicator]])])})))
 
 (defn- rows [grid-state]
-<<<<<<< a4c021eb5df761dbcc3beac10eeb070bc9cecc78
   (let [id              (-> @grid-state :id)
         total-width     (get-content-width grid-state)
         total-height    (get-content-height grid-state)

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -98,7 +98,7 @@
                                                                                                  clojure.string/lower-case)
                                                                                             comparator
                                                                                             rows))))))))))]
-               :when (:visible config)]
+               :when (:visible? config)]
            [:div {:key      (tily/format "grid-%s-%s-header" (:id @grid-state) column-kw)
                   :class    "mdl-button mdl-js-button mdl-js-button mdl-button--raised"
                   :style    (merge {:display   :table-cell
@@ -284,6 +284,7 @@
                                            [hover-indicator]])])})))
 
 (defn- rows [grid-state]
+<<<<<<< a4c021eb5df761dbcc3beac10eeb070bc9cecc78
   (let [id              (-> @grid-state :id)
         total-width     (get-content-width grid-state)
         total-height    (get-content-height grid-state)
@@ -384,12 +385,12 @@
                           :list-style-type :none}}
              (for [[i [column-kw config]] (tily/with-index columns-config)
                    :let [k (tily/format "spreadsheet-%s-cog-%s" id column-kw)
-                         visible? (:visible config)
+                         visible? (:visible? config)
                          ch (-> config :render-header-fn (apply nil))]]
                [:li {:key k}
                 [:label {:class "mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect" :for k}
                  [:input {:type "checkbox" :id k :class "mdl-checkbox__input" :defaultChecked visible?
-                          :on-change #(swap! grid-state update-in [:columns-config i 1 :visible] not)}]
+                          :on-change #(swap! grid-state update-in [:columns-config i 1 :visible?] not)}]
                  [:span {:class "mdl-checkbox__label"} ch]]])]])]))))
 
 (defn render [grid-state]

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -167,7 +167,7 @@
         select-row    #(swap! selected-rows conj i)
         unselect-row  (fn [] (swap! selected-rows (fn [selected-rows]
                                                     (set (filter #(not= i %) selected-rows)))))
-        build-style   (fn [i] (when (= i @number-button-hover-id)
+        hover-style   (fn [i] (when (= i @number-button-hover-id)
                                 {:background-color "#d9d9d9"}))
         hover-arrow   (fn [] (when (= i @number-button-hover-id)
                                [:i {:class "material-icons"} "arrow_drop_down"]))]
@@ -215,7 +215,7 @@
                                                                   :min-width left-corner-block-width
                                                                   :max-width left-corner-block-width
                                                                   :padding   0}
-                                                                 (build-style i))
+                                                                 (hover-style i))
                                               :on-click        #(if (tily/is-contained? i :in @selected-rows)
                                                                   (unselect-row)
                                                                   (select-row))

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -160,7 +160,7 @@
 
 
 ;; temporary atom, just to check
-(def number-button-hover? (r/atom false))
+(def number-button-hover-id (r/atom nil))
 
 (defn- number-button [i grid-state]
   (let [selected-rows (r/cursor grid-state [:selected-rows])

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -56,10 +56,10 @@
 
 (defn get-default-column-style [column-kw spreadsheet-state]
   (let [column-width (get-column-width column-kw spreadsheet-state)
-        style (merge {:width         column-width
-                      :min-width     column-width
-                      :max-width     column-width
-                      :text-align :center
+        style (merge {:width          column-width
+                      :min-width      column-width
+                      :max-width      column-width
+                      :text-align     :center
                       :vertical-align :middle}
                      common-column-style)]
     style))

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -270,6 +270,7 @@
         total-height   (get-content-height grid-state)
         columns-config (-> @grid-state :columns-config)
         selected-rows  (r/cursor grid-state [:selected-rows])
+        expanded-rows  (r/cursor grid-state [:expanded-rows])
         row-data       (fn [row]
                          (doall (for [[column-kw config] columns-config
                                       :let [render-column-fn (:render-column-fn config)

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -161,7 +161,7 @@
 
 (defn- number-button [i grid-state]
   (let [selected-rows   (r/cursor grid-state [:selected-rows])
-        expanded-rows  (r/cursor grid-state [:expanded-rows])
+        expanded-rows   (r/cursor grid-state [:expanded-rows])
         hovered-nb-row  (r/cursor grid-state [:hovered-number-button-row])
         select-row      #(swap! selected-rows conj i)
         unselect-row    (fn [] (swap! selected-rows (fn [selected-rows]
@@ -173,9 +173,12 @@
         hover-indicator (fn [] (when (= i @hovered-nb-row)
                                  [:i.material-icons {:style {:margin       -5
                                                              :margin-right -8}
-                                                      :on-click #(if (tily/is-contained? i :in @expanded-rows)
+                                                      :on-click (fn [evt]
+                                                                  (if (tily/is-contained? i :in @expanded-rows)
                                                                     (collapse-row)
-                                                                    (expand-row))}
+                                                                    (expand-row))
+                                                                  (.. evt stopPropagation)
+                                                                  (.. evt -nativeEvent stopImmediatePropagation))}
                                   "arrow_drop_down"]))]
     (r/create-class {:component-did-mount (fn [this-component]
                                             (let [this-element (r/dom-node this-component)

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -163,15 +163,15 @@
 (def number-button-hover-id (r/atom nil))
 
 (defn- number-button [i grid-state]
-  (let [selected-rows (r/cursor grid-state [:selected-rows])
-        select-row    #(swap! selected-rows conj i)
-        unselect-row  (fn [] (swap! selected-rows (fn [selected-rows]
-                                                    (set (filter #(not= i %) selected-rows)))))
-        hover-style   (fn [i] (when (= i @number-button-hover-id)
-                                {:background-color "#d9d9d9"}))
-        hover-arrow   (fn [] (when (= i @number-button-hover-id)
-                               [:i.material-icons {:style {:margin -5 :margin-right -8}}
-                                "arrow_drop_down"]))]
+  (let [selected-rows   (r/cursor grid-state [:selected-rows])
+        select-row      #(swap! selected-rows conj i)
+        unselect-row    (fn [] (swap! selected-rows (fn [selected-rows]
+                                                      (set (filter #(not= i %) selected-rows)))))
+        hover-style     (fn [i] (when (= i @number-button-hover-id)
+                                  {:background-color "#d9d9d9"}))
+        hover-indicator (fn [] (when (= i @number-button-hover-id)
+                                 [:i.material-icons {:style {:margin -5 :margin-right -8}}
+                                  "arrow_drop_down"]))]
     (r/create-class {:component-did-mount (fn [this-component]
                                             (let [this-element (r/dom-node this-component)
                                                   mc (js/Hammer. this-element)]
@@ -262,7 +262,7 @@
 
                                                                    (. evt preventDefault)))}
                                         (inc i)
-                                        [hover-arrow]])})))
+                                        [hover-indicator]])})))
 
 (defn- rows [grid-state]
   (let [id             (-> @grid-state :id)

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -181,7 +181,9 @@
                                                     (expand-row))
                                                   (.. evt stopPropagation)
                                                   (.. evt -nativeEvent stopImmediatePropagation))}
-                                  "arrow_drop_down"]))]
+                                   (if (tily/is-contained? i :in @expanded-rows)
+                                     "arrow_drop_up"
+                                     "arrow_drop_down")]))]
     (r/create-class {:component-did-mount (fn [this-component]
                                             (let [this-element (r/dom-node this-component)
                                                   mc (js/Hammer. this-element)]

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -394,6 +394,7 @@
 
 (defn render [grid-state]
   (r/create-class {:component-will-mount (fn [this-component]
+                                           (tily/set-atom! grid-state [:selected-rows] #{})
                                            (tily/set-atom! grid-state [:expanded-rows] #{})
                                            (tily/set-atom! grid-state [:id] (str (rand-int 1000))))
                    :reagent-render       (fn [grid-state]

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -363,6 +363,7 @@
 
 (defn render [grid-state]
   (r/create-class {:component-will-mount (fn [this-component]
+                                           (tily/set-atom! grid-state [:expanded-rows] #{})
                                            (tily/set-atom! grid-state [:id] (str (rand-int 1000))))
                    :reagent-render       (fn [grid-state]
                                            [:div {:on-click #(when (-> @grid-state :context-menu :content)

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -264,7 +264,7 @@
                                         (inc i)
                                         [hover-indicator i]])})))
 
-(defn- div* []
+(defn- extra-row []
   [:div {:style {:display :none}}
    "a hidden div"])
 
@@ -291,7 +291,7 @@
                             [:div {:style style}
                              [number-button i grid-state]
                              (row-data row)]
-                            [div*]]))]
+                            [extra-row]]))]
     [:div {:id    (tily/format "grid-%s-rows" id)
            :class "grid-rows"
            :style {:display    :block

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -24,11 +24,11 @@
 
 (defn get-invisible-columns [grid-state]
   (->> @grid-state :columns-config
-       (filter #(false? (-> % second :visible)))))
+       (filter #(false? (-> % second :visible?)))))
 
 (defn get-visible-columns [grid-state]
   (->> @grid-state :columns-config
-       (filter #(true? (-> % second :visible)))))
+       (filter #(true? (-> % second :visible?)))))
 
 (defn get-content-width [grid-state]
   (-> grid-state get-window-dimension :width))
@@ -159,7 +159,6 @@
                        (assoc property :on-input remote-save))]
     [:div property
      value]))
-
 
 (defn- number-button [i grid-state]
   (let [selected-rows   (r/cursor grid-state [:selected-rows])
@@ -293,6 +292,7 @@
         expanded-rows    (r/cursor grid-state [:expanded-rows])
         row-data         (fn [row reagent-key-fn {:keys [extra? visible?]}]
                            (doall (for [[column-kw config] columns-config
+                                        ;; use get-visible-columns, write filter-default-columns, etc.
                                         :when (if extra? (= extra? (:extra? config)) true)
                                         :when (if visible? (= visible? (:visible config)) true)
                                         :let [render-column-fn (:render-column-fn config)

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -170,7 +170,8 @@
         hover-style   (fn [i] (when (= i @number-button-hover-id)
                                 {:background-color "#d9d9d9"}))
         hover-arrow   (fn [] (when (= i @number-button-hover-id)
-                               [:i {:class "material-icons"} "arrow_drop_down"]))]
+                               [:i.material-icons {:style {:margin -5 :margin-right -8}}
+                                "arrow_drop_down"]))]
     (r/create-class {:component-did-mount (fn [this-component]
                                             (let [this-element (r/dom-node this-component)
                                                   mc (js/Hammer. this-element)]

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -215,6 +215,7 @@
                                                                                                                               constantly)]
                                                                                                        (on-delete-rows rows-to-delete)
 
+                                                                                                       (swap! expanded-rows clojure.set/difference @selected-rows)
                                                                                                        (reset! selected-rows #{})
                                                                                                        (tily/set-atom! grid-state [:rows] new-rows)))} "Delete"]]
                                                                          (swap! grid-state  (fn [grid-state]
@@ -272,6 +273,7 @@
                                                                                                                             constantly)]
                                                                                                      (on-delete-rows rows-to-delete)
 
+                                                                                                     (swap! expanded-rows clojure.set/difference @selected-rows)
                                                                                                      (reset! selected-rows #{})
                                                                                                      (tily/set-atom! grid-state [:rows] new-rows)))} "Delete"]]
                                                                        (tily/set-atom! grid-state [:context-menu :content] delete)

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -159,17 +159,15 @@
      value]))
 
 
-;; temporary atom, just to check
-(def number-button-hover-id (r/atom nil))
-
 (defn- number-button [i grid-state]
   (let [selected-rows   (r/cursor grid-state [:selected-rows])
+        hovered-nb-row  (r/cursor grid-state [:hovered-number-button-row])
         select-row      #(swap! selected-rows conj i)
         unselect-row    (fn [] (swap! selected-rows (fn [selected-rows]
                                                       (set (filter #(not= i %) selected-rows)))))
-        hover-style     (fn [i] (when (= i @number-button-hover-id)
+        hover-style     (fn [i] (when (= i @hovered-nb-row)
                                   {:background-color "#d9d9d9"}))
-        hover-indicator (fn [i] (when (= i @number-button-hover-id)
+        hover-indicator (fn [i] (when (= i @hovered-nb-row)
                                   [:i.material-icons {:style {:margin       -5
                                                               :margin-right -8}
                                                       :on-click #(js/alert "click")}
@@ -222,8 +220,8 @@
                                               :on-click        #(if (tily/is-contained? i :in @selected-rows)
                                                                   (unselect-row)
                                                                   (select-row))
-                                              :on-mouse-enter  (fn [_] (reset! number-button-hover-id i))
-                                              :on-mouse-leave  (fn [_] (reset! number-button-hover-id nil))
+                                              :on-mouse-enter  (fn [_] (reset! hovered-nb-row i))
+                                              :on-mouse-leave  (fn [_] (reset! hovered-nb-row nil))
                                               :on-drag-start   (fn [evt]
                                                                  (let [selected-row-indexes  (-> @grid-state (get-in [:selected-rows]))
                                                                        selected-entities     (-> @grid-state :rows

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -167,7 +167,7 @@
         select-row    #(swap! selected-rows conj i)
         unselect-row  (fn [] (swap! selected-rows (fn [selected-rows]
                                                     (set (filter #(not= i %) selected-rows)))))
-        build-style   (fn [] (if @number-button-hover?
+        build-style   (fn [] (if @number-button-hover-id
                                {:background-color "red"}))]
     (r/create-class {:component-did-mount (fn [this-component]
                                             (let [this-element (r/dom-node this-component)
@@ -217,8 +217,8 @@
                                               :on-click        #(if (tily/is-contained? i :in @selected-rows)
                                                                   (unselect-row)
                                                                   (select-row))
-                                              :on-mouse-enter  (fn [_] (reset! number-button-hover? true))
-                                              :on-mouse-leave  (fn [_] (reset! number-button-hover? false))
+                                              :on-mouse-enter  (fn [_] (reset! number-button-hover-id true))
+                                              :on-mouse-leave  (fn [_] (reset! number-button-hover-id false))
                                               :on-drag-start   (fn [evt]
                                                                  (let [selected-row-indexes  (-> @grid-state (get-in [:selected-rows]))
                                                                        selected-entities     (-> @grid-state :rows

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -64,9 +64,16 @@
                      common-column-style)]
     style))
 
+;; rename this fn
+(defn filter-normal-columns [column-config]
+  (let [[column-kw config] column-config]
+    (js/console.log (pr-str column-kw))
+    column-config))
+
+
 (defn- data-column-headers [grid-state]
   (doall (for [column-config (-> @grid-state :columns-config)
-               :let [[column-kw config] column-config
+               :let [[column-kw config] (filter-normal-columns column-config)
                      column-width   (get-column-width column-kw grid-state)
                      header-txt     (-> config :render-header-fn (apply nil))
                      sort-indicator (let [sort-column (-> @grid-state :sort-column)

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -172,8 +172,8 @@
         hover-style     (fn [] (when (= i @hovered-nb-row)
                                  {:background-color "#d9d9d9"}))
         hover-indicator (fn [] (when (= i @hovered-nb-row)
-                                 [:i.number-button-indicator.material-icons {:style {:margin       -5
-                                                                                     :margin-right -8}
+                                 [:i.number-button-indicator.material-icons {:style {:margin-left 5
+                                                                                     :margin-right -10}
                                                                              :on-click (fn [evt]
                                                                                          (if (tily/is-contained? i :in @expanded-rows)
                                                                                            (collapse-row)

--- a/src/com/kaicode/datagrid.cljs
+++ b/src/com/kaicode/datagrid.cljs
@@ -181,7 +181,7 @@
                                                     (expand-row))
                                                   (.. evt stopPropagation)
                                                   (.. evt -nativeEvent stopImmediatePropagation))}
-              "arrow_drop_down"]))]
+                                  "arrow_drop_down"]))]
     (r/create-class {:component-did-mount (fn [this-component]
                                             (let [this-element (r/dom-node this-component)
                                                   mc (js/Hammer. this-element)]


### PR DESCRIPTION
- Adds ability to expand and collapse rows, displaying additional data marked as `:extra?`.
- Correctly sets the width of `left-corner-block`.
- Fixes some smaller issues, for example `selected-rows` are now initially created as hash-sets.